### PR TITLE
Add thread lock on timer job

### DIFF
--- a/GameLiftGameServer/GameLiftGameServer/Timer.cpp
+++ b/GameLiftGameServer/GameLiftGameServer/Timer.cpp
@@ -16,6 +16,8 @@ void Timer::PushTimerJob(SessionPtr owner, const TimerTask& task, uint32_t after
 {
 	CRASH_ASSERT(LThreadType == THREAD_IO_WORKER);
 
+	FastSpinlockGuard writeLock(mLock);
+
 	int64_t dueTimeTick = after + LTickCount;
 
 	mTimerJobQueue.push(TimerJobElement(owner, task, dueTimeTick));
@@ -24,6 +26,9 @@ void Timer::PushTimerJob(SessionPtr owner, const TimerTask& task, uint32_t after
 
 void Timer::DoTimerJob()
 {
+	bool isExclusive = false;
+	FastSpinlockGuard readLock(mLock, isExclusive);
+
 	/// thread tick update
 	LTickCount = GetTickCount64();
 

--- a/GameLiftGameServer/GameLiftGameServer/Timer.h
+++ b/GameLiftGameServer/GameLiftGameServer/Timer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "FastSpinlock.h"
 
 class Session;
 typedef std::function<void()> TimerTask;
@@ -40,5 +41,6 @@ private:
 
 	TimerJobPriorityQueue	mTimerJobQueue;
 
-};
+	FastSpinlock	mLock;
 
+};


### PR DESCRIPTION
# Intro

The class `Timer`'s Queue has implemented with container `std::vector`, which is not thread safe for concurrent read & write.
# So what did i do?

Added `FastSpinLock` on class `Timer`. On `PushTimerJob`, Added exclusive lock to write, and on `DoTimerJob`, Added non-exclusive lock to read.
# Why `FastSpinLock`?

I don't know which thread lock-er is good for it, so just used `FastSpinLock` as other source.
